### PR TITLE
Include original filename in cropped filenames

### DIFF
--- a/DivideScannedImages.scm
+++ b/DivideScannedImages.scm
@@ -205,7 +205,7 @@
               (set! targetDir (unbreakupstr (butlast (strbreakup imgpath pathchar)) pathchar))
             )
             
-            (set! newFileName (string-append targetDir pathchar inFileName 
+            (set! newFileName (string-append targetDir pathchar gimp-image-get-filename inFileName 
                                      (substring "00000" (string-length (number->string (+ inFileNumber numextracted))))
                                      (number->string (+ inFileNumber numextracted)) saveString))
             (gimp-image-set-resolution tempImage 600 600)  ; The DPI


### PR DESCRIPTION
Per suggestion from https://github.com/FrancoisMalan/DivideScannedImages/issues/2